### PR TITLE
feat: Event Detail / Order Detail 페이지 + 행 클릭 네비게이션

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,9 @@ import DashboardPage from './pages/DashboardPage'
 import UsersPage from './pages/UsersPage'
 import UserDetailPage from './pages/UserDetailPage'
 import EventsPage from './pages/EventsPage'
+import EventDetailPage from './pages/EventDetailPage'
 import OrdersPage from './pages/OrdersPage'
+import OrderDetailPage from './pages/OrderDetailPage'
 import CommentsPage from './pages/CommentsPage'
 
 const queryClient = new QueryClient()
@@ -35,7 +37,9 @@ export default function App() {
             <Route path="users" element={<UsersPage />} />
             <Route path="users/:id" element={<UserDetailPage />} />
             <Route path="events" element={<EventsPage />} />
+            <Route path="events/:id" element={<EventDetailPage />} />
             <Route path="orders" element={<OrdersPage />} />
+            <Route path="orders/:uuid" element={<OrderDetailPage />} />
             <Route path="comments" element={<CommentsPage />} />
           </Route>
         </Routes>

--- a/src/__tests__/ProtectedRoute.test.tsx
+++ b/src/__tests__/ProtectedRoute.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
-import App from '../App'
 
 // Minimal test for ProtectedRoute logic
 describe('ProtectedRoute', () => {

--- a/src/__tests__/api-client.test.ts
+++ b/src/__tests__/api-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 
 describe('API Client', () => {
   beforeEach(() => {
@@ -13,7 +13,9 @@ describe('API Client', () => {
       const { default: client } = await import('../api/client')
 
       // Intercept the request config
-      const config = await client.interceptors.request.handlers[0].fulfilled!({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handlers = (client.interceptors.request as any).handlers
+      const config = await handlers[0].fulfilled!({
         headers: {} as any,
       } as any)
 
@@ -23,7 +25,9 @@ describe('API Client', () => {
     it('토큰이 없으면 헤더를 추가하지 않는다', async () => {
       const { default: client } = await import('../api/client')
 
-      const config = await client.interceptors.request.handlers[0].fulfilled!({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handlers = (client.interceptors.request as any).handlers
+      const config = await handlers[0].fulfilled!({
         headers: {} as any,
       } as any)
 
@@ -36,7 +40,8 @@ describe('API Client', () => {
       localStorage.setItem('admin_token', 'expired-token')
 
       const { default: client } = await import('../api/client')
-      const errorHandler = client.interceptors.response.handlers[0].rejected!
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const errorHandler = (client.interceptors.response as any).handlers[0].rejected!
 
       // Mock window.location
       const originalHref = window.location.href

--- a/src/__tests__/pages/LoginPage.test.tsx
+++ b/src/__tests__/pages/LoginPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'

--- a/src/pages/EventDetailPage.tsx
+++ b/src/pages/EventDetailPage.tsx
@@ -1,0 +1,130 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { ArrowLeft, Trash2, Clock, Users } from 'lucide-react'
+import { getEventDetail, deleteEvent } from '../api/admin'
+import type { AdminEvent } from '../types'
+import { cn } from '../lib/utils'
+
+const statusBadge: Record<string, string> = {
+  PREPARING: 'bg-yellow-100 text-yellow-700',
+  OPEN: 'bg-green-100 text-green-700',
+  CALCULATING: 'bg-blue-100 text-blue-700',
+  CLOSED: 'bg-gray-100 text-gray-700',
+  DELETED: 'bg-red-100 text-red-700',
+}
+
+export default function EventDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const eventId = Number(id)
+
+  const { data: event, isLoading } = useQuery<AdminEvent>({
+    queryKey: ['event', eventId],
+    queryFn: () => getEventDetail(eventId),
+    enabled: !isNaN(eventId),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteEvent(eventId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['events'] })
+      navigate('/events')
+    },
+  })
+
+  const handleDelete = () => {
+    if (window.confirm('이 이벤트를 삭제하시겠습니까? (소프트 삭제)')) {
+      deleteMutation.mutate()
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="animate-pulse space-y-4">
+        <div className="h-8 w-32 rounded bg-gray-200" />
+        <div className="h-64 rounded-xl bg-gray-200" />
+      </div>
+    )
+  }
+
+  if (!event) {
+    return (
+      <div className="text-center text-gray-500">
+        이벤트를 찾을 수 없습니다.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => navigate('/events')}
+        className="mb-6 flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        이벤트 목록으로
+      </button>
+
+      <div className="rounded-xl bg-white p-6 shadow-sm">
+        <div className="mb-6 flex items-start justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-gray-900">{event.name}</h2>
+            <p className="mt-1 text-sm text-gray-500">주최: {event.hostName}</p>
+          </div>
+          <span
+            className={cn(
+              'rounded-full px-3 py-1 text-xs font-medium',
+              statusBadge[event.status] ?? 'bg-gray-100 text-gray-700'
+            )}
+          >
+            {event.status}
+          </span>
+        </div>
+
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="flex items-start gap-3 rounded-lg bg-gray-50 p-4">
+            <Clock className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+            <div>
+              <dt className="text-sm text-gray-500">시작일시</dt>
+              <dd className="mt-1 font-medium text-gray-900">
+                {new Date(event.startAt).toLocaleString('ko-KR')}
+              </dd>
+            </div>
+          </div>
+          <div className="flex items-start gap-3 rounded-lg bg-gray-50 p-4">
+            <Clock className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+            <div>
+              <dt className="text-sm text-gray-500">런타임</dt>
+              <dd className="mt-1 font-medium text-gray-900">
+                {event.runTime}분
+              </dd>
+            </div>
+          </div>
+          <div className="flex items-start gap-3 rounded-lg bg-gray-50 p-4">
+            <Users className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+            <div>
+              <dt className="text-sm text-gray-500">생성일</dt>
+              <dd className="mt-1 font-medium text-gray-900">
+                {new Date(event.createdAt).toLocaleString('ko-KR')}
+              </dd>
+            </div>
+          </div>
+        </dl>
+
+        {event.status !== 'DELETED' && (
+          <div className="mt-6 border-t border-gray-200 pt-6">
+            <button
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+              className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+            >
+              <Trash2 className="h-4 w-4" />
+              이벤트 삭제
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import { Search, Trash2 } from 'lucide-react'
 import { getEvents, deleteEvent } from '../api/admin'
 import type { AdminEvent, Page } from '../types'
@@ -16,6 +17,7 @@ const statusBadge: Record<string, string> = {
 }
 
 export default function EventsPage() {
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [page, setPage] = useState(0)
   const [keyword, setKeyword] = useState('')
@@ -122,7 +124,7 @@ export default function EventsPage() {
                 </tr>
               ) : (
                 data?.content.map((event) => (
-                  <tr key={event.id} className="transition-colors hover:bg-gray-50">
+                  <tr key={event.id} onClick={() => navigate(`/events/${event.id}`)} className="cursor-pointer transition-colors hover:bg-gray-50">
                     <td className="px-4 py-3 text-gray-900">{event.id}</td>
                     <td className="px-4 py-3 font-medium text-gray-900">{event.name}</td>
                     <td className="px-4 py-3 text-gray-600">{event.hostName}</td>

--- a/src/pages/OrderDetailPage.tsx
+++ b/src/pages/OrderDetailPage.tsx
@@ -1,0 +1,142 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { ArrowLeft, XCircle, CreditCard, User, Calendar, Tag } from 'lucide-react'
+import { getOrderDetail, cancelOrder } from '../api/admin'
+import type { AdminOrder } from '../types'
+import { cn } from '../lib/utils'
+
+const statusBadge: Record<string, string> = {
+  CONFIRM: 'bg-green-100 text-green-700',
+  PENDING_APPROVE: 'bg-yellow-100 text-yellow-700',
+  REFUND: 'bg-orange-100 text-orange-700',
+  CANCELED: 'bg-red-100 text-red-700',
+  FAILED: 'bg-red-100 text-red-700',
+}
+
+export default function OrderDetailPage() {
+  const { uuid } = useParams<{ uuid: string }>()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const { data: order, isLoading } = useQuery<AdminOrder>({
+    queryKey: ['order', uuid],
+    queryFn: () => getOrderDetail(uuid!),
+    enabled: !!uuid,
+  })
+
+  const cancelMutation = useMutation({
+    mutationFn: () => cancelOrder(uuid!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['order', uuid] })
+      queryClient.invalidateQueries({ queryKey: ['orders'] })
+    },
+  })
+
+  const handleCancel = () => {
+    if (window.confirm('이 주문을 강제 취소하시겠습니까?')) {
+      cancelMutation.mutate()
+    }
+  }
+
+  const canCancel = (status: string) =>
+    status === 'CONFIRM' || status === 'PENDING_APPROVE'
+
+  if (isLoading) {
+    return (
+      <div className="animate-pulse space-y-4">
+        <div className="h-8 w-32 rounded bg-gray-200" />
+        <div className="h-64 rounded-xl bg-gray-200" />
+      </div>
+    )
+  }
+
+  if (!order) {
+    return (
+      <div className="text-center text-gray-500">
+        주문을 찾을 수 없습니다.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => navigate('/orders')}
+        className="mb-6 flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        주문 목록으로
+      </button>
+
+      <div className="rounded-xl bg-white p-6 shadow-sm">
+        <div className="mb-6 flex items-start justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-gray-900">주문 상세</h2>
+            <p className="mt-1 font-mono text-sm text-gray-500">{order.orderId}</p>
+          </div>
+          <span
+            className={cn(
+              'rounded-full px-3 py-1 text-xs font-medium',
+              statusBadge[order.orderStatus] ?? 'bg-gray-100 text-gray-700'
+            )}
+          >
+            {order.orderStatus}
+          </span>
+        </div>
+
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="flex items-start gap-3 rounded-lg bg-gray-50 p-4">
+            <User className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+            <div>
+              <dt className="text-sm text-gray-500">주문자</dt>
+              <dd className="mt-1 font-medium text-gray-900">{order.userName}</dd>
+            </div>
+          </div>
+          <div className="flex items-start gap-3 rounded-lg bg-gray-50 p-4">
+            <Calendar className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+            <div>
+              <dt className="text-sm text-gray-500">이벤트</dt>
+              <dd className="mt-1 font-medium text-gray-900">{order.eventName}</dd>
+            </div>
+          </div>
+          <div className="flex items-start gap-3 rounded-lg bg-gray-50 p-4">
+            <Tag className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+            <div>
+              <dt className="text-sm text-gray-500">티켓</dt>
+              <dd className="mt-1 font-medium text-gray-900">{order.ticketName}</dd>
+            </div>
+          </div>
+          <div className="flex items-start gap-3 rounded-lg bg-gray-50 p-4">
+            <CreditCard className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+            <div>
+              <dt className="text-sm text-gray-500">결제 금액</dt>
+              <dd className="mt-1 text-xl font-bold text-gray-900">
+                {order.totalAmount.toLocaleString('ko-KR')}원
+              </dd>
+            </div>
+          </div>
+        </dl>
+
+        <div className="mt-4 rounded-lg bg-gray-50 p-4">
+          <dt className="text-sm text-gray-500">주문일시</dt>
+          <dd className="mt-1 font-medium text-gray-900">
+            {new Date(order.createdAt).toLocaleString('ko-KR')}
+          </dd>
+        </div>
+
+        {canCancel(order.orderStatus) && (
+          <div className="mt-6 border-t border-gray-200 pt-6">
+            <button
+              onClick={handleCancel}
+              disabled={cancelMutation.isPending}
+              className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+            >
+              <XCircle className="h-4 w-4" />
+              주문 강제 취소
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/OrdersPage.tsx
+++ b/src/pages/OrdersPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import { Search, XCircle } from 'lucide-react'
 import { getOrders, cancelOrder } from '../api/admin'
 import type { AdminOrder, Page } from '../types'
@@ -16,6 +17,7 @@ const statusBadge: Record<string, string> = {
 }
 
 export default function OrdersPage() {
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [page, setPage] = useState(0)
   const [keyword, setKeyword] = useState('')
@@ -126,7 +128,7 @@ export default function OrdersPage() {
                 </tr>
               ) : (
                 data?.content.map((order) => (
-                  <tr key={order.orderId} className="transition-colors hover:bg-gray-50">
+                  <tr key={order.orderId} onClick={() => navigate(`/orders/${order.orderId}`)} className="cursor-pointer transition-colors hover:bg-gray-50">
                     <td className="px-4 py-3 font-mono text-xs text-gray-900">
                       {order.orderId.slice(0, 8)}...
                     </td>


### PR DESCRIPTION
## Summary

- EventDetailPage (`/events/:id`): 이벤트 상세 정보, 상태 뱃지, soft delete
- OrderDetailPage (`/orders/:uuid`): 주문 상세 정보, 결제 금액, 강제 취소
- EventsPage/OrdersPage 테이블 행 클릭 → 상세 페이지 이동
- 스켈레톤 로딩, 뒤로가기 네비게이션

close Gosrock/DuDoong-Backend#653

## Test plan

- [x] `npm test` — 16 passed
- [x] TypeScript `tsc -b --noEmit` 에러 없음
- [ ] 이벤트 행 클릭 → 상세 페이지 렌더링
- [ ] 주문 행 클릭 → 상세 페이지 렌더링

🤖 Generated with [Claude Code](https://claude.com/claude-code)