### PR TITLE
feat: 로컬 로그인 → 쿠키 기반 인증 전환

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,12 @@ import EventDetailPage from './pages/EventDetailPage'
 import OrdersPage from './pages/OrdersPage'
 import OrderDetailPage from './pages/OrderDetailPage'
 import CommentsPage from './pages/CommentsPage'
+import { hasAuthCookie } from './lib/utils'
 
 const queryClient = new QueryClient()
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const token = localStorage.getItem('admin_token')
-  if (!token) return <Navigate to="/login" replace />
+  if (!hasAuthCookie()) return <Navigate to="/login" replace />
   return <>{children}</>
 }
 

--- a/src/__tests__/ProtectedRoute.test.tsx
+++ b/src/__tests__/ProtectedRoute.test.tsx
@@ -1,52 +1,52 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { hasAuthCookie } from '../lib/utils'
 
-// Minimal test for ProtectedRoute logic
-describe('ProtectedRoute', () => {
-  beforeEach(() => {
-    localStorage.clear()
-  })
+afterEach(() => {
+  document.cookie = 'accessToken=; max-age=0'
+  document.cookie = 'stg_accessToken=; max-age=0'
+})
 
-  it('토큰이 없으면 /login으로 리다이렉트한다', () => {
+function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  if (!hasAuthCookie()) return <div>리다이렉트됨</div>
+  return <>{children}</>
+}
+
+describe('ProtectedRoute (쿠키 기반)', () => {
+  it('쿠키가 없으면 리다이렉트한다', () => {
     render(
       <MemoryRouter initialEntries={['/']}>
         <Routes>
-          <Route path="/login" element={<div>로그인 페이지</div>} />
-          <Route
-            path="/"
-            element={
-              (() => {
-                const token = localStorage.getItem('admin_token')
-                if (!token) return <div>리다이렉트됨</div>
-                return <div>대시보드</div>
-              })()
-            }
-          />
+          <Route path="/" element={<ProtectedRoute><div>대시보드</div></ProtectedRoute>} />
         </Routes>
       </MemoryRouter>
     )
     expect(screen.getByText('리다이렉트됨')).toBeInTheDocument()
   })
 
-  it('토큰이 있으면 자식을 렌더링한다', () => {
-    localStorage.setItem('admin_token', 'valid-token')
+  it('accessToken 쿠키가 있으면 자식을 렌더링한다', () => {
+    document.cookie = 'accessToken=valid-jwt-token'
     render(
       <MemoryRouter initialEntries={['/']}>
         <Routes>
-          <Route
-            path="/"
-            element={
-              (() => {
-                const token = localStorage.getItem('admin_token')
-                if (!token) return <div>리다이렉트됨</div>
-                return <div>대시보드</div>
-              })()
-            }
-          />
+          <Route path="/" element={<ProtectedRoute><div>대시보드</div></ProtectedRoute>} />
         </Routes>
       </MemoryRouter>
     )
     expect(screen.getByText('대시보드')).toBeInTheDocument()
+  })
+
+  it('stg_accessToken 쿠키가 있어도 localhost에서는 인식하지 않는다', () => {
+    document.cookie = 'stg_accessToken=staging-jwt-token'
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<ProtectedRoute><div>대시보드</div></ProtectedRoute>} />
+        </Routes>
+      </MemoryRouter>
+    )
+    // localhost에서는 accessToken을 찾으므로 stg_ 쿠키는 무시
+    expect(screen.getByText('리다이렉트됨')).toBeInTheDocument()
   })
 })

--- a/src/__tests__/api-client.test.ts
+++ b/src/__tests__/api-client.test.ts
@@ -1,62 +1,61 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 
-describe('API Client', () => {
-  beforeEach(() => {
-    localStorage.clear()
+afterEach(() => {
+  document.cookie = 'accessToken=; max-age=0'
+})
+
+describe('API Client (쿠키 기반)', () => {
+  it('withCredentials가 true로 설정되어 있다', async () => {
+    const { default: client } = await import('../api/client')
+    expect(client.defaults.withCredentials).toBe(true)
   })
 
-  describe('X-Admin-Token 인터셉터', () => {
-    it('토큰이 있으면 X-Admin-Token 헤더를 추가한다', async () => {
-      localStorage.setItem('admin_token', 'test-admin-jwt')
-
-      // Re-import to get fresh module
-      const { default: client } = await import('../api/client')
-
-      // Intercept the request config
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const handlers = (client.interceptors.request as any).handlers
-      const config = await handlers[0].fulfilled!({
-        headers: {} as any,
-      } as any)
-
-      expect(config.headers['X-Admin-Token']).toBe('test-admin-jwt')
+  it('X-Admin-Token 헤더를 사용하지 않는다 (request interceptor 없음)', async () => {
+    const { default: client } = await import('../api/client')
+    // request interceptor가 없거나 X-Admin-Token을 설정하지 않아야 함
+    const handlers = (client.interceptors.request as any).handlers
+    const hasAdminTokenInterceptor = handlers.some((h: any) => {
+      if (!h?.fulfilled) return false
+      const fnStr = h.fulfilled.toString()
+      return fnStr.includes('X-Admin-Token') || fnStr.includes('admin_token')
     })
-
-    it('토큰이 없으면 헤더를 추가하지 않는다', async () => {
-      const { default: client } = await import('../api/client')
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const handlers = (client.interceptors.request as any).handlers
-      const config = await handlers[0].fulfilled!({
-        headers: {} as any,
-      } as any)
-
-      expect(config.headers['X-Admin-Token']).toBeUndefined()
-    })
+    expect(hasAdminTokenInterceptor).toBe(false)
   })
 
-  describe('401 응답 처리', () => {
-    it('401 응답 시 admin_token을 삭제한다', async () => {
-      localStorage.setItem('admin_token', 'expired-token')
+  it('401 응답 시 메인 사이트로 리다이렉트한다', async () => {
+    const { default: client } = await import('../api/client')
+    const errorHandler = (client.interceptors.response as any).handlers[0].rejected!
 
-      const { default: client } = await import('../api/client')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const errorHandler = (client.interceptors.response as any).handlers[0].rejected!
-
-      // Mock window.location
-      const originalHref = window.location.href
-      Object.defineProperty(window, 'location', {
-        value: { href: originalHref },
-        writable: true,
-      })
-
-      try {
-        await errorHandler({ response: { status: 401 } })
-      } catch {
-        // Expected rejection
-      }
-
-      expect(localStorage.getItem('admin_token')).toBeNull()
+    const originalHref = window.location.href
+    Object.defineProperty(window, 'location', {
+      value: { href: originalHref, hostname: 'localhost' },
+      writable: true,
     })
+
+    try {
+      await errorHandler({ response: { status: 401 } })
+    } catch {
+      // Expected rejection
+    }
+
+    expect(window.location.href).toBe('http://localhost:3000')
+  })
+
+  it('403 응답 시 메인 사이트로 리다이렉트한다', async () => {
+    const { default: client } = await import('../api/client')
+    const errorHandler = (client.interceptors.response as any).handlers[0].rejected!
+
+    Object.defineProperty(window, 'location', {
+      value: { href: '', hostname: 'localhost' },
+      writable: true,
+    })
+
+    try {
+      await errorHandler({ response: { status: 403 } })
+    } catch {
+      // Expected rejection
+    }
+
+    expect(window.location.href).toBe('http://localhost:3000')
   })
 })

--- a/src/__tests__/pages/LoginPage.test.tsx
+++ b/src/__tests__/pages/LoginPage.test.tsx
@@ -1,6 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { server } from '../../test/mocks/server'
@@ -9,7 +8,9 @@ import LoginPage from '../../pages/LoginPage'
 beforeAll(() => server.listen())
 afterEach(() => {
   server.resetHandlers()
-  localStorage.clear()
+  // 쿠키 초기화
+  document.cookie = 'accessToken=; max-age=0'
+  document.cookie = 'stg_accessToken=; max-age=0'
 })
 afterAll(() => server.close())
 
@@ -25,38 +26,21 @@ function renderWithProviders(ui: React.ReactElement) {
 }
 
 describe('LoginPage', () => {
-  it('로그인 폼을 렌더링한다', () => {
+  it('쿠키 없으면 메인 사이트 이동 안내를 보여준다', () => {
     renderWithProviders(<LoginPage />)
     expect(screen.getByText('DuDoong Admin')).toBeInTheDocument()
-    expect(screen.getByText('관리자 로그인')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('admin@dudoong.com')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('관리자')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '로그인' })).toBeInTheDocument()
+    expect(screen.getByText('관리자 전용 페이지입니다')).toBeInTheDocument()
+    expect(screen.getByText('메인 사이트로 이동')).toBeInTheDocument()
+    expect(screen.getByText('메인 사이트로 이동').closest('a')).toHaveAttribute('href', 'http://localhost:3000')
   })
 
-  it('로그인 성공 시 토큰을 저장한다', async () => {
-    const user = userEvent.setup()
+  it('쿠키 있지만 권한 없으면(403) 권한 없음 메시지를 보여준다', async () => {
+    document.cookie = 'accessToken=invalid-token'
     renderWithProviders(<LoginPage />)
 
-    await user.type(screen.getByPlaceholderText('admin@dudoong.com'), 'admin@dudoong.com')
-    await user.type(screen.getByPlaceholderText('관리자'), '관리자')
-    await user.click(screen.getByRole('button', { name: '로그인' }))
-
+    // getAdminMe 호출 후 403 → 권한 없음 표시
     await waitFor(() => {
-      expect(localStorage.getItem('admin_token')).toBe('mock-admin-token')
-    })
-  })
-
-  it('USER 역할로 로그인 시 에러 메시지를 표시한다', async () => {
-    const user = userEvent.setup()
-    renderWithProviders(<LoginPage />)
-
-    await user.type(screen.getByPlaceholderText('admin@dudoong.com'), 'forbidden@dudoong.com')
-    await user.type(screen.getByPlaceholderText('관리자'), '일반유저')
-    await user.click(screen.getByRole('button', { name: '로그인' }))
-
-    await waitFor(() => {
-      expect(screen.getByText('로그인에 실패했습니다. 관리자 계정인지 확인해주세요.')).toBeInTheDocument()
+      expect(screen.getByText('관리자 권한이 없는 계정입니다.')).toBeInTheDocument()
     })
   })
 })

--- a/src/__tests__/ux/accessibility.test.tsx
+++ b/src/__tests__/ux/accessibility.test.tsx
@@ -8,7 +8,10 @@ import LoginPage from '../../pages/LoginPage'
 import EventsPage from '../../pages/EventsPage'
 
 beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  document.cookie = 'accessToken=; max-age=0'
+})
 afterAll(() => server.close())
 
 function renderWithProviders(ui: React.ReactElement) {
@@ -28,18 +31,17 @@ describe('접근성', () => {
     expect(screen.getByLabelText('메뉴 열기')).toBeInTheDocument()
   })
 
-  it('LoginPage 이메일 input에 label이 연결되어 있다', () => {
+  it('LoginPage 쿠키 없을 때 메인 사이트 링크가 있다', () => {
     renderWithProviders(<LoginPage />)
-    const emailInput = screen.getByLabelText('이메일')
-    expect(emailInput).toBeInTheDocument()
-    expect(emailInput.tagName).toBe('INPUT')
+    const link = screen.getByText('메인 사이트로 이동')
+    expect(link).toBeInTheDocument()
+    expect(link.tagName).toBe('A')
   })
 
-  it('LoginPage 이름 input에 label이 연결되어 있다', () => {
+  it('LoginPage 쿠키 있고 권한 없을 때 안내 메시지가 있다', () => {
+    document.cookie = 'accessToken=some-token'
     renderWithProviders(<LoginPage />)
-    const nameInput = screen.getByLabelText('이름')
-    expect(nameInput).toBeInTheDocument()
-    expect(nameInput.tagName).toBe('INPUT')
+    expect(screen.getByText('관리자 권한이 없는 계정입니다.')).toBeInTheDocument()
   })
 
   it('EventsPage 테이블 헤더에 scope="col"이 있다', async () => {

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -37,19 +37,5 @@ export const deleteComment = (commentId: number) =>
   client.delete(`/internal-api/v1/comments/${commentId}`)
 
 // Auth
-export const adminLogin = (email: string, name: string) =>
-  client.post('/internal-api/v1/auth/oauth/local/login', {
-    email,
-    name,
-    phoneNumber: '010-0000-0000',
-    profileImage: null,
-    marketingAgree: false,
-  }).then(r => r.data.data)
-
 export const getAdminMe = () =>
   client.get('/internal-api/v1/auth/me').then(r => r.data.data)
-
-export const adminRefreshToken = (refreshToken: string) =>
-  client.post('/internal-api/v1/auth/token/refresh', null, {
-    params: { token: refreshToken },
-  }).then(r => r.data.data)

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,23 +1,16 @@
 import axios from 'axios'
+import { getMainSiteUrl } from '../lib/utils'
 
 const client = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '',
-})
-
-client.interceptors.request.use((config) => {
-  const token = localStorage.getItem('admin_token')
-  if (token) {
-    config.headers['X-Admin-Token'] = token
-  }
-  return config
+  withCredentials: true,
 })
 
 client.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.status === 401) {
-      localStorage.removeItem('admin_token')
-      window.location.href = '/login'
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      window.location.href = getMainSiteUrl()
     }
     return Promise.reject(error)
   }

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -10,7 +10,7 @@ import {
   Menu,
   X,
 } from 'lucide-react'
-import { cn } from '../lib/utils'
+import { cn, getMainSiteUrl } from '../lib/utils'
 
 const navItems = [
   { to: '/', icon: LayoutDashboard, label: '대시보드', end: true },
@@ -25,8 +25,7 @@ export default function AdminLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   const handleLogout = () => {
-    localStorage.removeItem('admin_token')
-    navigate('/login')
+    window.location.href = getMainSiteUrl()
   }
 
   const sidebar = (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,25 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getMainSiteUrl(): string {
+  const host = window.location.hostname
+  if (host.includes('staging')) return 'https://staging.dudoong.com'
+  if (host.includes('dudoong.com')) return 'https://dudoong.com'
+  return 'http://localhost:3000'
+}
+
+export function getAccessTokenCookieName(): string {
+  const host = window.location.hostname
+  if (host.includes('staging')) return 'stg_accessToken'
+  return 'accessToken'
+}
+
+export function getCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`))
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+export function hasAuthCookie(): boolean {
+  return getCookie(getAccessTokenCookieName()) !== null
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,29 +1,24 @@
-import { useState } from 'react'
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { adminLogin } from '../api/admin'
+import { getMainSiteUrl, hasAuthCookie } from '../lib/utils'
+import { getAdminMe } from '../api/admin'
 
 export default function LoginPage() {
   const navigate = useNavigate()
-  const [email, setEmail] = useState('')
-  const [name, setName] = useState('')
-  const [error, setError] = useState('')
-  const [loading, setLoading] = useState(false)
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError('')
-    setLoading(true)
-
-    try {
-      const data = await adminLogin(email, name)
-      localStorage.setItem('admin_token', data.accessToken)
-      navigate('/', { replace: true })
-    } catch {
-      setError('로그인에 실패했습니다. 관리자 계정인지 확인해주세요.')
-    } finally {
-      setLoading(false)
+  useEffect(() => {
+    if (hasAuthCookie()) {
+      // 쿠키 있으면 권한 확인
+      getAdminMe()
+        .then(() => navigate('/', { replace: true }))
+        .catch(() => {
+          // 403 = 권한 없음 (ADMIN/SUPER_ADMIN 아님)
+          // 여기서는 리다이렉트하지 않고 안내 메시지 표시
+        })
     }
-  }
+  }, [navigate])
+
+  const mainSiteUrl = getMainSiteUrl()
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100 px-4">
@@ -31,53 +26,32 @@ export default function LoginPage() {
         <h1 className="mb-2 text-center text-2xl font-bold text-gray-900">
           DuDoong Admin
         </h1>
-        <p className="mb-8 text-center text-sm text-gray-500">
-          관리자 로그인
+        <p className="mb-6 text-center text-sm text-gray-500">
+          관리자 전용 페이지입니다
         </p>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label htmlFor="login-email" className="mb-1 block text-sm font-medium text-gray-700">
-              이메일
-            </label>
-            <input
-              id="login-email"
-              type="email"
-              required
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-              placeholder="admin@dudoong.com"
-            />
+        {hasAuthCookie() ? (
+          <div className="text-center">
+            <p className="mb-4 text-sm text-red-600">
+              관리자 권한이 없는 계정입니다.
+            </p>
+            <p className="text-xs text-gray-400">
+              ADMIN 이상 권한이 필요합니다.
+            </p>
           </div>
-
-          <div>
-            <label htmlFor="login-name" className="mb-1 block text-sm font-medium text-gray-700">
-              이름
-            </label>
-            <input
-              id="login-name"
-              type="text"
-              required
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-              placeholder="관리자"
-            />
-          </div>
-
-          {error && (
-            <p role="alert" className="text-sm text-red-600">{error}</p>
-          )}
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {loading ? '로그인 중...' : '로그인'}
-          </button>
-        </form>
+        ) : (
+          <>
+            <p className="mb-6 text-center text-sm text-gray-600">
+              메인 사이트에서 로그인 후 다시 방문해주세요.
+            </p>
+            <a
+              href={mainSiteUrl}
+              className="block w-full rounded-lg bg-blue-600 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-blue-700"
+            >
+              메인 사이트로 이동
+            </a>
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -53,22 +53,29 @@ export const handlers = [
     })
   ),
 
-  // Admin login
-  http.post('*/internal-api/v1/auth/oauth/local/login', async ({ request }) => {
-    const body = (await request.json()) as { email?: string }
-    if (body.email === 'forbidden@dudoong.com') {
-      return HttpResponse.json({ status: 403, code: 'ADMIN_FORBIDDEN' }, { status: 403 })
+  // Admin me (권한 확인)
+  http.get('*/internal-api/v1/auth/me', ({ cookies }) => {
+    // 쿠키에 accessToken이 있고 유효한 경우 ADMIN 정보 반환
+    // 테스트에서는 쿠키 값으로 분기
+    if (cookies.accessToken === 'valid-admin-token') {
+      return HttpResponse.json({
+        status: 200,
+        data: {
+          id: 1,
+          name: '관리자',
+          email: 'admin@dudoong.com',
+          profileImage: null,
+          accountRole: 'ADMIN',
+          accountState: 'NORMAL',
+          phoneNumber: '010-0000-0000',
+          marketingAgree: false,
+          oauthProvider: 'KAKAO',
+          createdAt: '2026-01-01T00:00:00',
+        },
+      })
     }
-    return HttpResponse.json({
-      status: 200,
-      data: {
-        accessToken: 'mock-admin-token',
-        refreshToken: 'mock-refresh-token',
-        accessTokenAge: 3600,
-        refreshTokenAge: 7200,
-        userProfile: { name: '관리자', email: body.email },
-      },
-    })
+    // 권한 없는 유저 또는 유효하지 않은 토큰
+    return HttpResponse.json({ status: 403, code: 'ADMIN_FORBIDDEN' }, { status: 403 })
   }),
 
   // Events list


### PR DESCRIPTION
## Summary
- 로컬 로그인(이메일+이름) 제거, 메인 사이트 카카오 로그인 쿠키 공유 방식으로 전환
- localStorage/X-Admin-Token → withCredentials 쿠키 기반 인증
- 권한 없는 사용자 안내 페이지 추가 (ADMIN/SUPER_ADMIN 아닌 경우)
- 스테이징/프로덕션 쿠키 이름 자동 분기 (stg_ prefix)
- 테스트 35개 전부 통과

관련 백엔드 PR: Gosrock/DuDoong-Backend#662

close #16

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] Vitest 35개 테스트 통과
- [ ] 스테이징 배포 후 실제 쿠키 공유 확인