### PR TITLE
feat: 어드민 응답 필드 화면 표시 + E2E 현대화

### DIFF
--- a/.omc/state/agent-replay-aa22b131-3340-4a1d-8df7-2032e911f22e.jsonl
+++ b/.omc/state/agent-replay-aa22b131-3340-4a1d-8df7-2032e911f22e.jsonl
@@ -1,0 +1,4 @@
+{"t":0,"agent":"a6440a1","agent_type":"explore","event":"agent_start","parent_mode":"none"}
+{"t":0,"agent":"a6440a1","agent_type":"explore","event":"agent_stop","success":true,"duration_ms":51689}
+{"t":0,"agent":"a16933e","agent_type":"executor","event":"agent_start","parent_mode":"none"}
+{"t":0,"agent":"a16933e","agent_type":"executor","event":"agent_stop","success":true,"duration_ms":140809}

--- a/.omc/state/hud-state.json
+++ b/.omc/state/hud-state.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-03-21T11:53:00.772Z",
+  "timestamp": "2026-03-22T07:02:29.456Z",
   "backgroundTasks": [],
-  "sessionStartTimestamp": "2026-03-21T11:45:43.474Z",
-  "sessionId": "6160cf8f4df2afaa"
+  "sessionStartTimestamp": "2026-03-22T05:50:50.058Z",
+  "sessionId": "92dce8c970e6a0c0"
 }

--- a/.omc/state/subagent-tracking.json
+++ b/.omc/state/subagent-tracking.json
@@ -69,10 +69,28 @@
       "status": "completed",
       "completed_at": "2026-03-21T14:19:42.339Z",
       "duration_ms": 103519
+    },
+    {
+      "agent_id": "a6440a16387991b30",
+      "agent_type": "oh-my-claudecode:explore",
+      "started_at": "2026-03-22T07:02:36.512Z",
+      "parent_mode": "none",
+      "status": "completed",
+      "completed_at": "2026-03-22T07:03:28.201Z",
+      "duration_ms": 51689
+    },
+    {
+      "agent_id": "a16933e953693b1b6",
+      "agent_type": "oh-my-claudecode:executor",
+      "started_at": "2026-03-22T07:03:52.942Z",
+      "parent_mode": "none",
+      "status": "completed",
+      "completed_at": "2026-03-22T07:06:13.751Z",
+      "duration_ms": 140809
     }
   ],
-  "total_spawned": 8,
-  "total_completed": 7,
+  "total_spawned": 10,
+  "total_completed": 9,
   "total_failed": 0,
-  "last_updated": "2026-03-21T14:19:42.442Z"
+  "last_updated": "2026-03-22T07:06:13.854Z"
 }

--- a/e2e/run.ts
+++ b/e2e/run.ts
@@ -3,7 +3,7 @@
  *
  * 실행 전 필수:
  *   1. cd DuDoong-Backend && docker compose up -d
- *   2. SPRING_PROFILES_ACTIVE=infrastructure,domain,domain-local,common ./gradlew :DuDoong-Api:bootRun
+ *   2. ./gradlew :DuDoong-Api:bootRun --args='--spring.profiles.active=local,infrastructure,domain,domain-local,common,common-local'
  *   3. cd DuDoong-Admin-Front && npm run test:e2e
  *
  * 환경변수:
@@ -23,9 +23,9 @@ let adminToken = ''
 
 async function request(method: string, url: string, body?: unknown, headers?: Record<string, string>) {
   const h: Record<string, string> = { 'Content-Type': 'application/json', ...headers }
-  const skipAuth = headers && 'X-Admin-Token' in headers
-  if (adminToken && !skipAuth && !headers?.Authorization) {
-    h['X-Admin-Token'] = adminToken
+  // 기본적으로 Authorization Bearer 헤더로 토큰 전달
+  if (adminToken && !headers?.Authorization) {
+    h['Authorization'] = `Bearer ${adminToken}`
   }
   const res = await fetch(url, {
     method,
@@ -60,26 +60,26 @@ async function exec(cmd: string): Promise<string> {
 async function setupAdminUser(): Promise<boolean> {
   console.log('\n🔧 테스트 Admin 유저 셋업')
 
-  // 1. Admin login으로 유저 생성 (403이지만 DB에 저장됨)
-  await request('POST', `${ADMIN_API}/auth/oauth/local/login`, {
+  // 1. 일반 로그인으로 유저 생성
+  await request('POST', `${PUBLIC_API}/auth/oauth/local/login`, {
     email: 'e2e-admin@dudoong.com',
     name: 'E2E관리자',
     phoneNumber: '010-9999-9999',
     profileImage: null,
     marketingAgree: false,
-  })
+  }, { Authorization: '' })  // 기존 토큰 무시
 
-  // 2. MySQL에서 role을 MANAGER로 업그레이드
-  await exec(`${MYSQL_SETUP} "UPDATE tbl_user SET account_role='MANAGER' WHERE email='e2e-admin@dudoong.com' AND account_role='USER'"`)
+  // 2. MySQL에서 role을 ADMIN으로 업그레이드
+  await exec(`${MYSQL_SETUP} "UPDATE tbl_user SET account_role='ADMIN' WHERE email='e2e-admin@dudoong.com'"`)
 
-  // 3. 다시 로그인 → admin 토큰 획득
-  const { status, data } = await request('POST', `${ADMIN_API}/auth/oauth/local/login`, {
+  // 3. 다시 로그인 → 토큰 획득 (JwtTokenFilter가 DB에서 role 실시간 조회)
+  const { status, data } = await request('POST', `${PUBLIC_API}/auth/oauth/local/login`, {
     email: 'e2e-admin@dudoong.com',
     name: 'E2E관리자',
     phoneNumber: '010-9999-9999',
     profileImage: null,
     marketingAgree: false,
-  })
+  }, { Authorization: '' })
 
   if (status === 200 && data?.accessToken) {
     adminToken = data.accessToken
@@ -99,14 +99,20 @@ async function testAuthFlow() {
   const { status: meStatus, data: meData } = await request('GET', `${ADMIN_API}/auth/me`)
   assert('/me 정상 응답', meStatus === 200, `status=${meStatus}`)
   assert('/me에 이메일 포함', meData?.email === 'e2e-admin@dudoong.com', `email=${meData?.email}`)
-  assert('/me에 역할 포함', meData?.accountRole === 'MANAGER', `role=${meData?.accountRole}`)
+  assert('/me에 역할 포함', meData?.accountRole === 'ADMIN', `role=${meData?.accountRole}`)
 
-  // USER 역할 → admin 로그인 차단
-  const { status: blockedStatus } = await request('POST', `${ADMIN_API}/auth/oauth/local/login`, {
+  // USER 역할 → admin API 차단
+  // 일반 로그인으로 USER 유저 생성
+  const { data: blockedData } = await request('POST', `${PUBLIC_API}/auth/oauth/local/login`, {
     email: 'e2e-blocked@dudoong.com', name: 'E2E차단유저',
     phoneNumber: '010-0000-0001', profileImage: null, marketingAgree: false,
-  })
-  assert('USER 역할 admin 로그인 → 403', blockedStatus === 403, `status=${blockedStatus}`)
+  }, { Authorization: '' })
+  if (blockedData?.accessToken) {
+    const { status: blockedStatus } = await request('GET', `${ADMIN_API}/dashboard`, undefined, {
+      Authorization: `Bearer ${blockedData.accessToken}`,
+    })
+    assert('USER 역할 admin API → 403', blockedStatus === 403, `status=${blockedStatus}`)
+  }
 }
 
 // ─── Test: Dashboard ─────────────────────────────────────
@@ -152,7 +158,7 @@ async function testUsers() {
   assert('키워드 검색 정상', searchStatus === 200, `status=${searchStatus}`)
   assert('검색 결과에 E2E관리자 포함', searchData?.content?.some((u: any) => u.name === 'E2E관리자'), `found=${searchData?.content?.length}`)
 
-  // 상세 조회
+  // 상세 조회 + 새 필드 검증
   if (listData?.content?.length > 0) {
     const userId = listData.content[0].id
     const { status: detailStatus, data: detailData } = await request('GET', `${ADMIN_API}/users/${userId}`)
@@ -160,6 +166,9 @@ async function testUsers() {
     assert('상세에 phoneNumber 포함', 'phoneNumber' in (detailData ?? {}), `keys=${Object.keys(detailData ?? {})}`)
     assert('상세에 oauthProvider 포함', 'oauthProvider' in (detailData ?? {}))
     assert('상세에 marketingAgree 포함', 'marketingAgree' in (detailData ?? {}))
+    // 새 필드
+    assert('상세에 lastLoginAt 포함', 'lastLoginAt' in (detailData ?? {}))
+    assert('상세에 receiveMail 포함', 'receiveMail' in (detailData ?? {}))
   }
 }
 
@@ -180,10 +189,16 @@ async function testEvents() {
     assert('이벤트에 hostName 필드', typeof event.hostName === 'string')
     assert('이벤트에 status 필드', typeof event.status === 'string')
     assert('이벤트에 startAt 필드', typeof event.startAt === 'string')
+    // 새 필드
+    assert('이벤트에 hostId 필드', 'hostId' in event)
 
     // 상세 조회
-    const { status: detailStatus } = await request('GET', `${ADMIN_API}/events/${event.id}`)
+    const { status: detailStatus, data: detailData } = await request('GET', `${ADMIN_API}/events/${event.id}`)
     assert('이벤트 상세 정상', detailStatus === 200, `status=${detailStatus}`)
+    if (detailData) {
+      assert('상세에 hostId 포함', 'hostId' in detailData)
+      assert('상세에 posterImageKey 포함', 'posterImageKey' in detailData)
+    }
   } else {
     console.log('  ⚠️ 이벤트 데이터 없음 — 상세/삭제 테스트 스킵')
   }
@@ -206,10 +221,20 @@ async function testOrders() {
     assert('주문에 eventName 필드', typeof order.eventName === 'string')
     assert('주문에 totalAmount 필드', typeof order.totalAmount === 'string' || typeof order.totalAmount === 'number')
     assert('주문에 orderStatus 필드', typeof order.orderStatus === 'string')
+    // 새 필드
+    assert('주문에 userId 필드', 'userId' in order)
+    assert('주문에 eventId 필드', 'eventId' in order)
+    assert('주문에 orderNo 필드', 'orderNo' in order)
+    assert('주문에 orderMethod 필드', 'orderMethod' in order)
 
     // 상세 조회
-    const { status: detailStatus } = await request('GET', `${ADMIN_API}/orders/${order.orderId}`)
+    const { status: detailStatus, data: detailData } = await request('GET', `${ADMIN_API}/orders/${order.orderId}`)
     assert('주문 상세 정상', detailStatus === 200, `status=${detailStatus}`)
+    if (detailData) {
+      assert('상세에 paymentMethod 포함', 'paymentMethod' in detailData)
+      assert('상세에 supplyAmount 포함', 'supplyAmount' in detailData)
+      assert('상세에 discountAmount 포함', 'discountAmount' in detailData)
+    }
   } else {
     console.log('  ⚠️ 주문 데이터 없음 — 상세 테스트 스킵')
   }
@@ -231,6 +256,9 @@ async function testComments() {
     assert('댓글에 userName 필드', typeof comment.userName === 'string')
     assert('댓글에 content 필드', typeof comment.content === 'string')
     assert('댓글에 commentStatus 필드', typeof comment.commentStatus === 'string')
+    // 새 필드
+    assert('댓글에 userId 필드', 'userId' in comment)
+    assert('댓글에 eventId 필드', 'eventId' in comment)
   } else {
     console.log('  ⚠️ 댓글 데이터 없음 — 필드 테스트 스킵')
   }
@@ -241,25 +269,19 @@ async function testComments() {
 async function testAccessControl() {
   console.log('\n📋 접근 제어')
 
-  // 미인증 차단
+  // 미인증 차단 — 토큰 없이 직접 fetch
   const endpoints = ['/dashboard', '/users', '/events', '/orders', '/comments']
   for (const ep of endpoints) {
-    const { status } = await request('GET', `${ADMIN_API}${ep}`, undefined, { 'X-Admin-Token': '' })
-    assert(`미인증 ${ep} → 차단`, status === 401 || status === 403, `status=${status}`)
+    const res = await fetch(`${ADMIN_API}${ep}`)
+    const json = await res.json().catch(() => null)
+    assert(`미인증 ${ep} → 차단`, res.status === 401 || res.status === 403, `status=${res.status}`)
   }
 
   // 가짜 토큰 차단
   const { status: fakeStatus } = await request('GET', `${ADMIN_API}/dashboard`, undefined, {
-    'X-Admin-Token': 'fake-invalid-token',
+    Authorization: 'Bearer fake-invalid-token',
   })
   assert('가짜 토큰 → 차단', fakeStatus === 401 || fakeStatus === 403, `status=${fakeStatus}`)
-
-  // Authorization 헤더(일반 토큰 방식)로 admin API 차단
-  const { status: bearerStatus } = await request('GET', `${ADMIN_API}/dashboard`, undefined, {
-    Authorization: `Bearer ${adminToken}`,
-    'X-Admin-Token': '',
-  })
-  assert('Bearer 헤더 → admin API 차단', bearerStatus === 401 || bearerStatus === 403, `status=${bearerStatus}`)
 }
 
 // ─── Test: Role Change + Immediate Effect ────────────────
@@ -267,37 +289,30 @@ async function testAccessControl() {
 async function testRoleChangeEffect() {
   console.log('\n📋 역할 변경 즉시 반영')
 
-  // 테스트용 유저 생성
-  await request('POST', `${ADMIN_API}/auth/oauth/local/login`, {
+  // 테스트용 유저 생성 (일반 로그인)
+  await request('POST', `${PUBLIC_API}/auth/oauth/local/login`, {
     email: 'e2e-roletest@dudoong.com', name: 'E2E역할테스트',
     phoneNumber: '010-8888-7777', profileImage: null, marketingAgree: false,
-  })
+  }, { Authorization: '' })
 
   // MySQL에서 SUPER_ADMIN으로 현재 admin 유저 승격 (role 변경 API 테스트용)
   await exec(`${MYSQL_SETUP} "UPDATE tbl_user SET account_role='SUPER_ADMIN' WHERE email='e2e-admin@dudoong.com'"`)
-
-  // 토큰 재발급 (새 role 반영)
-  const { data: loginData } = await request('POST', `${ADMIN_API}/auth/oauth/local/login`, {
-    email: 'e2e-admin@dudoong.com', name: 'E2E관리자',
-    phoneNumber: '010-9999-9999', profileImage: null, marketingAgree: false,
-  })
-  adminToken = loginData?.accessToken ?? adminToken
 
   // roletest 유저 찾기
   const { data: searchData } = await request('GET', `${ADMIN_API}/users?keyword=e2e-roletest`)
   const targetUser = searchData?.content?.find((u: any) => u.email === 'e2e-roletest@dudoong.com')
 
   if (targetUser) {
-    // MANAGER로 역할 변경
+    // ADMIN으로 역할 변경
     const { status: roleStatus, data: roleData } = await request(
-      'PATCH', `${ADMIN_API}/users/${targetUser.id}/role`, { role: 'MANAGER' }
+      'PATCH', `${ADMIN_API}/users/${targetUser.id}/role`, { role: 'ADMIN' }
     )
     assert('역할 변경 API 성공', roleStatus === 200, `status=${roleStatus}`)
-    assert('변경 후 역할 = MANAGER', roleData?.accountRole === 'MANAGER', `role=${roleData?.accountRole}`)
+    assert('변경 후 역할 = ADMIN', roleData?.accountRole === 'ADMIN', `role=${roleData?.accountRole}`)
 
     // 즉시 반영 확인 — 상세 조회
     const { data: detailData } = await request('GET', `${ADMIN_API}/users/${targetUser.id}`)
-    assert('상세에서도 MANAGER 확인', detailData?.accountRole === 'MANAGER', `role=${detailData?.accountRole}`)
+    assert('상세에서도 ADMIN 확인', detailData?.accountRole === 'ADMIN', `role=${detailData?.accountRole}`)
 
     // 다시 USER로 복원
     const { status: revertStatus } = await request(
@@ -308,8 +323,8 @@ async function testRoleChangeEffect() {
     console.log('  ⚠️ roletest 유저를 찾을 수 없음')
   }
 
-  // admin을 MANAGER로 복원
-  await exec(`${MYSQL_SETUP} "UPDATE tbl_user SET account_role='MANAGER' WHERE email='e2e-admin@dudoong.com'"`)
+  // admin을 ADMIN으로 복원
+  await exec(`${MYSQL_SETUP} "UPDATE tbl_user SET account_role='ADMIN' WHERE email='e2e-admin@dudoong.com'"`)
 }
 
 // ─── Main ────────────────────────────────────────────────
@@ -321,11 +336,11 @@ async function main() {
 
   // 서버 연결 확인
   try {
-    await fetch(`${PUBLIC_API}/v1/examples/health`, { signal: AbortSignal.timeout(5000) })
+    await fetch(`${PUBLIC_API}/examples/health`, { signal: AbortSignal.timeout(5000) })
   } catch {
     console.error('\n❌ 서버에 연결할 수 없습니다.')
     console.error('   1. cd DuDoong-Backend && docker compose up -d')
-    console.error('   2. SPRING_PROFILES_ACTIVE=infrastructure,domain,domain-local,common ./gradlew :DuDoong-Api:bootRun')
+    console.error('   2. ./gradlew :DuDoong-Api:bootRun --args=\'--spring.profiles.active=local,infrastructure,domain,domain-local,common,common-local\'')
     process.exit(1)
   }
 

--- a/src/pages/CommentsPage.tsx
+++ b/src/pages/CommentsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useSearchParams, useNavigate } from 'react-router-dom'
+import { useSearchParams, useNavigate, Link } from 'react-router-dom'
 import { Search, Trash2 } from 'lucide-react'
 import { getComments, deleteComment } from '../api/admin'
 import type { AdminComment, Page } from '../types'
@@ -172,8 +172,24 @@ export default function CommentsPage() {
                 sortedData.map((comment) => (
                   <tr key={comment.id} className="transition-colors hover:bg-gray-50">
                     <td className="px-4 py-3 text-gray-900">{comment.id}</td>
-                    <td className="px-4 py-3 text-gray-900">{comment.userName}</td>
-                    <td className="px-4 py-3 text-gray-600">{comment.eventName}</td>
+                    <td className="px-4 py-3 text-gray-900">
+                      {comment.userId !== undefined ? (
+                        <Link to={`/users/${comment.userId}`} className="text-blue-600 hover:underline">
+                          {comment.userName}
+                        </Link>
+                      ) : (
+                        comment.userName
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">
+                      {comment.eventId !== undefined ? (
+                        <Link to={`/events/${comment.eventId}`} className="text-blue-600 hover:underline">
+                          {comment.eventName}
+                        </Link>
+                      ) : (
+                        comment.eventName
+                      )}
+                    </td>
                     <td className="max-w-xs truncate px-4 py-3 text-gray-600" title={comment.content}>
                       {comment.content.length > 50
                         ? comment.content.slice(0, 50) + '...'

--- a/src/pages/EventDetailPage.tsx
+++ b/src/pages/EventDetailPage.tsx
@@ -292,8 +292,24 @@ export default function EventDetailPage() {
         <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h2 className="text-xl font-bold text-gray-900">{event.name}</h2>
-            <p className="mt-1 text-sm text-gray-500">주최: {event.hostName}</p>
+            <p className="mt-1 text-sm text-gray-500">
+              주최:{' '}
+              {event.hostId ? (
+                <Link to={`/hosts/${event.hostId}`} className="text-blue-600 hover:underline">
+                  {event.hostName}
+                </Link>
+              ) : (
+                event.hostName
+              )}
+            </p>
           </div>
+          {event.posterImageKey && (
+            <img
+              src={`https://asset.dudoong.com/${event.posterImageKey}`}
+              alt="포스터"
+              className="mt-2 h-24 w-auto rounded-lg object-cover"
+            />
+          )}
           <div className="flex items-center gap-2 self-start">
             <span
               className={cn(
@@ -380,6 +396,17 @@ export default function EventDetailPage() {
             <div className="rounded-lg bg-gray-50 p-4 sm:col-span-2 lg:col-span-3">
               <dt className="text-sm text-gray-500">설명</dt>
               <dd className="mt-1 whitespace-pre-wrap text-sm text-gray-900">{event.content}</dd>
+            </div>
+          )}
+          {event.latitude !== undefined && event.longitude !== undefined && (
+            <div className="flex items-start gap-3 rounded-lg bg-gray-50 p-4">
+              <MapPin className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+              <div>
+                <dt className="text-sm text-gray-500">좌표</dt>
+                <dd className="mt-1 font-mono text-sm text-gray-900">
+                  {event.latitude}, {event.longitude}
+                </dd>
+              </div>
             </div>
           )}
         </dl>

--- a/src/pages/HostDetailPage.tsx
+++ b/src/pages/HostDetailPage.tsx
@@ -182,6 +182,21 @@ export default function HostDetailPage() {
               {new Date(host.createdAt).toLocaleString('ko-KR')}
             </dd>
           </div>
+          {host.slackUrl && (
+            <div className="rounded-lg bg-gray-50 p-4">
+              <dt className="text-sm text-gray-500">Slack URL</dt>
+              <dd className="mt-1 font-medium text-gray-900">
+                <a
+                  href={host.slackUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline break-all"
+                >
+                  {host.slackUrl}
+                </a>
+              </dd>
+            </div>
+          )}
         </dl>
 
         <div className="mt-6 flex flex-wrap items-center gap-3 border-t border-gray-200 pt-6">

--- a/src/pages/OrderDetailPage.tsx
+++ b/src/pages/OrderDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, XCircle, CreditCard, User, Calendar, Tag } from 'lucide-react'
 import { getOrderDetail, cancelOrder } from '../api/admin'
@@ -128,6 +128,117 @@ export default function OrderDetailPage() {
             {new Date(order.createdAt).toLocaleString('ko-KR')}
           </dd>
         </div>
+
+        {/* 주문 정보 섹션 */}
+        {(order.orderNo || order.orderMethod || order.userId !== undefined || order.eventId !== undefined) && (
+          <div className="mt-4 rounded-xl border border-gray-200 p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">주문 정보</h3>
+            <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {order.orderNo && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">주문번호</dt>
+                  <dd className="mt-0.5 font-mono text-sm font-medium text-gray-900">{order.orderNo}</dd>
+                </div>
+              )}
+              {order.orderMethod && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">주문방식</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">
+                    {order.orderMethod === 'PAYMENT' ? '결제' : order.orderMethod === 'APPROVAL' ? '승인' : order.orderMethod}
+                  </dd>
+                </div>
+              )}
+              {order.userId !== undefined && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">유저</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-blue-600">
+                    <Link to={`/users/${order.userId}`} className="hover:underline">
+                      #{order.userId} {order.userName}
+                    </Link>
+                  </dd>
+                </div>
+              )}
+              {order.eventId !== undefined && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">이벤트</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-blue-600">
+                    <Link to={`/events/${order.eventId}`} className="hover:underline">
+                      #{order.eventId} {order.eventName}
+                    </Link>
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        )}
+
+        {/* 결제 상세 섹션 */}
+        {(order.paymentMethod || order.supplyAmount || order.discountAmount || order.couponName || order.receiptUrl) && (
+          <div className="mt-4 rounded-xl border border-gray-200 p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">결제 상세</h3>
+            <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {order.paymentMethod && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">결제수단</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.paymentMethod}</dd>
+                </div>
+              )}
+              {order.supplyAmount && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">공급금액</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.supplyAmount}</dd>
+                </div>
+              )}
+              {order.discountAmount && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">할인금액</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.discountAmount}</dd>
+                </div>
+              )}
+              {order.couponName && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">쿠폰</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.couponName}</dd>
+                </div>
+              )}
+              {order.receiptUrl && (
+                <div className="rounded-lg bg-gray-50 p-3 sm:col-span-2">
+                  <dt className="text-xs text-gray-500">영수증</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-blue-600">
+                    <a href={order.receiptUrl} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                      영수증 보기
+                    </a>
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        )}
+
+        {/* 시간 정보 섹션 */}
+        {(order.approvedAt || order.withDrawAt) && (
+          <div className="mt-4 rounded-xl border border-gray-200 p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">시간 정보</h3>
+            <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {order.approvedAt && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">승인일시</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">
+                    {new Date(order.approvedAt).toLocaleString('ko-KR')}
+                  </dd>
+                </div>
+              )}
+              {order.withDrawAt && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">취소/환불일시</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">
+                    {new Date(order.withDrawAt).toLocaleString('ko-KR')}
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        )}
 
         {canCancel(order.orderStatus) && (
           <div className="mt-6 border-t border-gray-200 pt-6">

--- a/src/pages/UserDetailPage.tsx
+++ b/src/pages/UserDetailPage.tsx
@@ -138,6 +138,22 @@ export default function UserDetailPage() {
               {new Date(user.createdAt).toLocaleString('ko-KR')}
             </dd>
           </div>
+          {user.lastLoginAt && (
+            <div className="rounded-lg bg-gray-50 p-4">
+              <dt className="text-sm text-gray-500">마지막 로그인</dt>
+              <dd className="mt-1 font-medium text-gray-900">
+                {new Date(user.lastLoginAt).toLocaleString('ko-KR')}
+              </dd>
+            </div>
+          )}
+          {user.receiveMail !== undefined && (
+            <div className="rounded-lg bg-gray-50 p-4">
+              <dt className="text-sm text-gray-500">메일 수신 동의</dt>
+              <dd className="mt-1 font-medium text-gray-900">
+                {user.receiveMail ? '동의' : '거부'}
+              </dd>
+            </div>
+          )}
         </dl>
 
         <div className="mt-6 flex flex-col gap-3 border-t border-gray-200 pt-6 sm:flex-row sm:flex-wrap sm:items-center">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,6 +26,8 @@ export interface AdminUserDetail extends AdminUser {
   phoneNumber: string | null
   marketingAgree: boolean
   oauthProvider: string | null
+  lastLoginAt?: string
+  receiveMail?: boolean
 }
 
 export interface AdminEvent {
@@ -36,6 +38,10 @@ export interface AdminEvent {
   startAt: string
   runTime: number
   createdAt: string
+  hostId?: number
+  posterImageKey?: string
+  latitude?: number
+  longitude?: number
 }
 
 export interface AdminEventDetail extends AdminEvent {
@@ -77,6 +83,17 @@ export interface AdminOrder {
   totalAmount: number
   orderStatus: string
   createdAt: string
+  orderNo?: string
+  orderMethod?: string
+  userId?: number
+  eventId?: number
+  approvedAt?: string
+  withDrawAt?: string
+  paymentMethod?: string
+  receiptUrl?: string
+  supplyAmount?: string
+  discountAmount?: string
+  couponName?: string
 }
 
 export interface AdminComment {
@@ -86,6 +103,8 @@ export interface AdminComment {
   content: string
   commentStatus: string
   createdAt: string
+  userId?: number
+  eventId?: number
 }
 
 export interface AdminHost {
@@ -98,6 +117,7 @@ export interface AdminHost {
   partner: boolean
   masterUserId: number
   createdAt: string
+  slackUrl?: string
 }
 
 export interface AdminHostMember {


### PR DESCRIPTION
## Summary

Backend Api v2.2.0 어드민 응답 필드 보강에 맞춰 프론트 업데이트.

### 화면 변경
- **UserDetailPage**: 마지막 로그인, 메일 수신 동의 표시
- **EventDetailPage**: 호스트 링크, 포스터 이미지, 좌표 표시
- **OrderDetailPage**: 주문번호, 결제수단, 할인/쿠폰, 승인/취소 시각 섹션 추가
- **CommentsPage**: 유저/이벤트 링크 추가
- **타입 정의**: 20개 새 필드 (optional)

### E2E 현대화
- `X-Admin-Token` → `Authorization: Bearer` 전환
- `MANAGER` → `ADMIN` role
- 어드민 전용 로그인 → 일반 로그인 + DB 역할 승격

### 테스트
- [x] 유닛 테스트 37 passed
- [x] E2E 76 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)