### PR TITLE
feat: 경로 기반 라우팅 전환 (/internal-admin/)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+      <BrowserRouter basename="/internal-admin">
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig(({ mode }) => ({
+  base: '/internal-admin/',
   plugins: [react()],
   server: {
     proxy: mode === 'local' ? {


### PR DESCRIPTION
## Summary

서브도메인(`staging-internal-admin.dudoong.com`) → 경로 기반(`staging.dudoong.com/internal-admin/`) 전환.

- `vite.config.ts`: `base: '/internal-admin/'`
- `App.tsx`: `BrowserRouter basename="/internal-admin"`

### 테스트
- [x] 빌드 통과
- [x] 37 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)