### PR TITLE
fix: 환불 플로우 리디자인 UI 반영

### DIFF
--- a/.omc/state/agent-replay-aa22b131-3340-4a1d-8df7-2032e911f22e.jsonl
+++ b/.omc/state/agent-replay-aa22b131-3340-4a1d-8df7-2032e911f22e.jsonl
@@ -2,3 +2,5 @@
 {"t":0,"agent":"a6440a1","agent_type":"explore","event":"agent_stop","success":true,"duration_ms":51689}
 {"t":0,"agent":"a16933e","agent_type":"executor","event":"agent_start","parent_mode":"none"}
 {"t":0,"agent":"a16933e","agent_type":"executor","event":"agent_stop","success":true,"duration_ms":140809}
+{"t":0,"agent":"a0001fc","agent_type":"deep-executor","event":"agent_start","parent_mode":"none"}
+{"t":0,"agent":"a0001fc","agent_type":"deep-executor","event":"agent_stop","success":true,"duration_ms":299135}

--- a/.omc/state/subagent-tracking.json
+++ b/.omc/state/subagent-tracking.json
@@ -87,10 +87,19 @@
       "status": "completed",
       "completed_at": "2026-03-22T07:06:13.751Z",
       "duration_ms": 140809
+    },
+    {
+      "agent_id": "a0001fcd50035d4b6",
+      "agent_type": "oh-my-claudecode:deep-executor",
+      "started_at": "2026-03-22T11:12:21.897Z",
+      "parent_mode": "none",
+      "status": "completed",
+      "completed_at": "2026-03-22T11:17:21.032Z",
+      "duration_ms": 299135
     }
   ],
-  "total_spawned": 10,
-  "total_completed": 9,
+  "total_spawned": 11,
+  "total_completed": 10,
   "total_failed": 0,
-  "last_updated": "2026-03-22T07:06:13.854Z"
+  "last_updated": "2026-03-22T11:17:21.135Z"
 }

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -39,6 +39,10 @@ export const updateTicketItem = (eventId: number, ticketItemId: number, data: {
 export const adjustTicketStock = (eventId: number, ticketItemId: number, delta: number) =>
   client.post(`/internal-api/v1/events/${eventId}/ticket-items/${ticketItemId}/adjust-stock`, { delta }).then(r => r.data.data)
 
+// Users - name
+export const updateUserName = (userId: number, name: string) =>
+  client.patch(`/internal-api/v1/users/${userId}/name`, { name }).then(r => r.data.data)
+
 // Orders
 export const getOrders = (params: { page?: number; size?: number; keyword?: string; status?: string; eventId?: number }) =>
   client.get('/internal-api/v1/orders', { params }).then(r => r.data.data)
@@ -46,6 +50,10 @@ export const getOrderDetail = (orderUuid: string) =>
   client.get(`/internal-api/v1/orders/${orderUuid}`).then(r => r.data.data)
 export const cancelOrder = (orderUuid: string) =>
   client.post(`/internal-api/v1/orders/${orderUuid}/cancel`).then(r => r.data.data)
+export const cancelOrderWithReason = (orderUuid: string, reason?: string) =>
+  client.post(`/internal-api/v1/orders/${orderUuid}/cancel`, { reason }).then(r => r.data.data)
+export const updateOrderRefundStatus = (orderUuid: string, refundStatus: string, reason?: string) =>
+  client.patch(`/internal-api/v1/orders/${orderUuid}/refund-status`, { refundStatus, reason }).then(r => r.data.data)
 
 // Comments
 export const getComments = (params: { page?: number; size?: number; keyword?: string; eventId?: number }) =>
@@ -74,6 +82,8 @@ export const updateHostProfile = (hostId: number, data: {
   client.patch(`/internal-api/v1/hosts/${hostId}/profile`, data).then(r => r.data.data)
 export const getHostEvents = (hostId: number, params: { page?: number; size?: number }) =>
   client.get(`/internal-api/v1/hosts/${hostId}/events`, { params }).then(r => r.data.data)
+export const transferHostMaster = (hostId: number, newMasterUserId: number) =>
+  client.post(`/internal-api/v1/hosts/${hostId}/transfer-master`, { newMasterUserId }).then(r => r.data.data)
 
 // Exports
 export const exportOrders = (params: { keyword?: string; status?: string; eventId?: number }) =>

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -31,7 +31,6 @@ export const refundStatusLabel: Record<string, string> = {
   NONE: '없음',
   REFUND_REQUESTED: '환불 요청',
   REFUND_COMPLETED: '환불 완료',
-  REFUND_REJECTED: '환불 거절',
 }
 
 export const commentStatusLabel: Record<string, string> = {

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -27,6 +27,13 @@ export const orderStatusLabel: Record<string, string> = {
   FAILED: '실패',
 }
 
+export const refundStatusLabel: Record<string, string> = {
+  NONE: '없음',
+  REFUND_REQUESTED: '환불 요청',
+  REFUND_COMPLETED: '환불 완료',
+  REFUND_REJECTED: '환불 거절',
+}
+
 export const commentStatusLabel: Record<string, string> = {
   ACTIVE: '활성',
   DELETED: '삭제됨',

--- a/src/pages/HostDetailPage.tsx
+++ b/src/pages/HostDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   removeHostMember,
   updateHostPartner,
   updateHostProfile,
+  transferHostMaster,
 } from '../api/admin'
 import type { AdminHost, AdminHostMember } from '../types'
 import { cn } from '../lib/utils'
@@ -37,6 +38,7 @@ export default function HostDetailPage() {
   const [addRole, setAddRole] = useState('GUEST')
   const [pendingRoleChange, setPendingRoleChange] = useState<{ userId: number; role: string } | null>(null)
   const [roleConfirmOpen, setRoleConfirmOpen] = useState(false)
+  const [transferConfirmUserId, setTransferConfirmUserId] = useState<number | null>(null)
   const [profileEditOpen, setProfileEditOpen] = useState(false)
   const [profileName, setProfileName] = useState('')
   const [profileIntroduce, setProfileIntroduce] = useState('')
@@ -116,6 +118,18 @@ export default function HostDetailPage() {
     },
     onError: () => {
       toast.error('프로필 수정에 실패했습니다.')
+    },
+  })
+
+  const transferMasterMutation = useMutation({
+    mutationFn: (newMasterUserId: number) => transferHostMaster(hostId, newMasterUserId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['host', hostId] })
+      queryClient.invalidateQueries({ queryKey: ['host-members', hostId] })
+      toast.success('마스터가 변경되었습니다.')
+    },
+    onError: () => {
+      toast.error('마스터 변경에 실패했습니다.')
     },
   })
 
@@ -305,13 +319,24 @@ export default function HostDetailPage() {
                       </span>
                     </td>
                     <td className="px-4 py-3">
-                      <button
-                        onClick={() => setRemoveConfirmUserId(member.userId)}
-                        disabled={removeMemberMutation.isPending}
-                        className="rounded-lg px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
-                      >
-                        제거
-                      </button>
+                      <div className="flex items-center gap-1">
+                        {member.role !== 'MASTER' && (
+                          <button
+                            onClick={() => setTransferConfirmUserId(member.userId)}
+                            disabled={transferMasterMutation.isPending}
+                            className="rounded-lg px-3 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50 disabled:opacity-50"
+                          >
+                            마스터로 지정
+                          </button>
+                        )}
+                        <button
+                          onClick={() => setRemoveConfirmUserId(member.userId)}
+                          disabled={removeMemberMutation.isPending}
+                          className="rounded-lg px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
+                        >
+                          제거
+                        </button>
+                      </div>
                     </td>
                   </tr>
                 ))
@@ -364,6 +389,20 @@ export default function HostDetailPage() {
           setRemoveConfirmUserId(null)
         }}
         onCancel={() => setRemoveConfirmUserId(null)}
+      />
+
+      {/* 마스터 양도 확인 모달 */}
+      <ConfirmModal
+        open={transferConfirmUserId !== null}
+        title="마스터 양도"
+        description="이 유저를 호스트 마스터로 지정하시겠습니까? 기존 마스터는 매니저로 변경됩니다."
+        confirmLabel="양도"
+        variant="danger"
+        onConfirm={() => {
+          if (transferConfirmUserId !== null) transferMasterMutation.mutate(transferConfirmUserId)
+          setTransferConfirmUserId(null)
+        }}
+        onCancel={() => setTransferConfirmUserId(null)}
       />
 
       {/* 멤버 추가 모달 */}

--- a/src/pages/OrderDetailPage.tsx
+++ b/src/pages/OrderDetailPage.tsx
@@ -21,7 +21,6 @@ const refundStatusBadge: Record<string, string> = {
   NONE: 'bg-gray-100 text-gray-700',
   REFUND_REQUESTED: 'bg-yellow-100 text-yellow-700',
   REFUND_COMPLETED: 'bg-green-100 text-green-700',
-  REFUND_REJECTED: 'bg-red-100 text-red-700',
 }
 
 export default function OrderDetailPage() {
@@ -67,13 +66,6 @@ export default function OrderDetailPage() {
   const handleRefundComplete = () => {
     if (!confirm('환불을 완료 처리하시겠습니까?\n\n⚠️ 이 작업은 되돌릴 수 없습니다.')) return
     refundStatusMutation.mutate({ refundStatus: 'REFUND_COMPLETED' })
-  }
-
-  const handleRefundReject = () => {
-    if (!confirm('환불을 거절하시겠습니까?\n\n⚠️ 이 작업은 되돌릴 수 없습니다.')) return
-    const reason = prompt('환불 거절 사유를 입력하세요:')
-    if (reason === null) return
-    refundStatusMutation.mutate({ refundStatus: 'REFUND_REJECTED', reason })
   }
 
   const canCancel = (s: string) => s === 'CONFIRM' || s === 'PENDING_APPROVE'
@@ -283,12 +275,6 @@ export default function OrderDetailPage() {
               </span>
             </div>
             <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {order.userRefundReason && (
-                <div className="rounded-lg bg-gray-50 p-3">
-                  <dt className="text-xs text-gray-500">유저 환불 사유</dt>
-                  <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.userRefundReason}</dd>
-                </div>
-              )}
               {order.cancelReason && (
                 <div className="rounded-lg bg-gray-50 p-3">
                   <dt className="text-xs text-gray-500">취소 사유</dt>
@@ -319,13 +305,6 @@ export default function OrderDetailPage() {
                 >
                   환불 완료
                 </button>
-                <button
-                  onClick={handleRefundReject}
-                  disabled={refundStatusMutation.isPending}
-                  className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
-                >
-                  환불 거절
-                </button>
               </div>
             )}
           </div>
@@ -333,16 +312,10 @@ export default function OrderDetailPage() {
 
         {/* 사유 필드 (환불 상태가 없을 때도 표시) */}
         {!order.refundStatus || order.refundStatus === 'NONE' ? (
-          (order.failReason || order.userRefundReason || order.cancelReason) && (
+          (order.failReason || order.cancelReason) && (
             <div className="mt-4 rounded-xl border border-gray-200 p-4">
               <h3 className="mb-3 text-sm font-semibold text-gray-700">사유 정보</h3>
               <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                {order.userRefundReason && (
-                  <div className="rounded-lg bg-gray-50 p-3">
-                    <dt className="text-xs text-gray-500">유저 환불 사유</dt>
-                    <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.userRefundReason}</dd>
-                  </div>
-                )}
                 {order.cancelReason && (
                   <div className="rounded-lg bg-gray-50 p-3">
                     <dt className="text-xs text-gray-500">취소 사유</dt>

--- a/src/pages/OrderDetailPage.tsx
+++ b/src/pages/OrderDetailPage.tsx
@@ -2,11 +2,10 @@ import { useState } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, XCircle, CreditCard, User, Calendar, Tag } from 'lucide-react'
-import { getOrderDetail, cancelOrder } from '../api/admin'
+import { getOrderDetail, cancelOrderWithReason, updateOrderRefundStatus } from '../api/admin'
 import type { AdminOrder } from '../types'
 import { cn } from '../lib/utils'
-import { label, orderStatusLabel } from '../lib/labels'
-import ConfirmModal from '../components/ConfirmModal'
+import { label, orderStatusLabel, refundStatusLabel } from '../lib/labels'
 import ToastContainer from '../components/ToastContainer'
 import { useToast } from '../hooks/useToast'
 
@@ -18,13 +17,21 @@ const statusBadge: Record<string, string> = {
   FAILED: 'bg-red-100 text-red-700',
 }
 
+const refundStatusBadge: Record<string, string> = {
+  NONE: 'bg-gray-100 text-gray-700',
+  REFUND_REQUESTED: 'bg-yellow-100 text-yellow-700',
+  REFUND_COMPLETED: 'bg-green-100 text-green-700',
+  REFUND_REJECTED: 'bg-red-100 text-red-700',
+}
+
 export default function OrderDetailPage() {
   const { uuid } = useParams<{ uuid: string }>()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const toast = useToast()
 
-  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [cancelReasonOpen, setCancelReasonOpen] = useState(false)
+  const [cancelReason, setCancelReason] = useState('')
 
   const { data: order, isLoading } = useQuery<AdminOrder>({
     queryKey: ['order', uuid],
@@ -33,7 +40,7 @@ export default function OrderDetailPage() {
   })
 
   const cancelMutation = useMutation({
-    mutationFn: () => cancelOrder(uuid!),
+    mutationFn: (reason?: string) => cancelOrderWithReason(uuid!, reason),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['order', uuid] })
       queryClient.invalidateQueries({ queryKey: ['orders'] })
@@ -43,6 +50,31 @@ export default function OrderDetailPage() {
       toast.error('주문 취소에 실패했습니다.')
     },
   })
+
+  const refundStatusMutation = useMutation({
+    mutationFn: ({ refundStatus, reason }: { refundStatus: string; reason?: string }) =>
+      updateOrderRefundStatus(uuid!, refundStatus, reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['order', uuid] })
+      queryClient.invalidateQueries({ queryKey: ['orders'] })
+      toast.success('환불 상태가 변경되었습니다.')
+    },
+    onError: () => {
+      toast.error('환불 상태 변경에 실패했습니다.')
+    },
+  })
+
+  const handleRefundComplete = () => {
+    if (!confirm('환불을 완료 처리하시겠습니까?\n\n⚠️ 이 작업은 되돌릴 수 없습니다.')) return
+    refundStatusMutation.mutate({ refundStatus: 'REFUND_COMPLETED' })
+  }
+
+  const handleRefundReject = () => {
+    if (!confirm('환불을 거절하시겠습니까?\n\n⚠️ 이 작업은 되돌릴 수 없습니다.')) return
+    const reason = prompt('환불 거절 사유를 입력하세요:')
+    if (reason === null) return
+    refundStatusMutation.mutate({ refundStatus: 'REFUND_REJECTED', reason })
+  }
 
   const canCancel = (s: string) => s === 'CONFIRM' || s === 'PENDING_APPROVE'
 
@@ -240,10 +272,98 @@ export default function OrderDetailPage() {
           </div>
         )}
 
+        {/* 환불 상태 섹션 */}
+        {order.refundStatus && order.refundStatus !== 'NONE' && (
+          <div className="mt-4 rounded-xl border border-gray-200 p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">환불 정보</h3>
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-sm text-gray-500">환불 상태:</span>
+              <span className={cn('inline-block rounded-full px-2.5 py-0.5 text-xs font-medium', refundStatusBadge[order.refundStatus] ?? 'bg-gray-100 text-gray-700')}>
+                {label(refundStatusLabel, order.refundStatus)}
+              </span>
+            </div>
+            <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {order.userRefundReason && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">유저 환불 사유</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.userRefundReason}</dd>
+                </div>
+              )}
+              {order.cancelReason && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">취소 사유</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.cancelReason}</dd>
+                </div>
+              )}
+              {order.failReason && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">실패 사유</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.failReason}</dd>
+                </div>
+              )}
+              {order.refundStatusChangedAt && (
+                <div className="rounded-lg bg-gray-50 p-3">
+                  <dt className="text-xs text-gray-500">환불 상태 변경일</dt>
+                  <dd className="mt-0.5 text-sm font-medium text-gray-900">
+                    {new Date(order.refundStatusChangedAt).toLocaleString('ko-KR')}
+                  </dd>
+                </div>
+              )}
+            </dl>
+            {order.refundStatus === 'REFUND_REQUESTED' && (
+              <div className="mt-4 flex gap-2">
+                <button
+                  onClick={handleRefundComplete}
+                  disabled={refundStatusMutation.isPending}
+                  className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+                >
+                  환불 완료
+                </button>
+                <button
+                  onClick={handleRefundReject}
+                  disabled={refundStatusMutation.isPending}
+                  className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+                >
+                  환불 거절
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 사유 필드 (환불 상태가 없을 때도 표시) */}
+        {!order.refundStatus || order.refundStatus === 'NONE' ? (
+          (order.failReason || order.userRefundReason || order.cancelReason) && (
+            <div className="mt-4 rounded-xl border border-gray-200 p-4">
+              <h3 className="mb-3 text-sm font-semibold text-gray-700">사유 정보</h3>
+              <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {order.userRefundReason && (
+                  <div className="rounded-lg bg-gray-50 p-3">
+                    <dt className="text-xs text-gray-500">유저 환불 사유</dt>
+                    <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.userRefundReason}</dd>
+                  </div>
+                )}
+                {order.cancelReason && (
+                  <div className="rounded-lg bg-gray-50 p-3">
+                    <dt className="text-xs text-gray-500">취소 사유</dt>
+                    <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.cancelReason}</dd>
+                  </div>
+                )}
+                {order.failReason && (
+                  <div className="rounded-lg bg-gray-50 p-3">
+                    <dt className="text-xs text-gray-500">실패 사유</dt>
+                    <dd className="mt-0.5 text-sm font-medium text-gray-900">{order.failReason}</dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+          )
+        ) : null}
+
         {canCancel(order.orderStatus) && (
           <div className="mt-6 border-t border-gray-200 pt-6">
             <button
-              onClick={() => setConfirmOpen(true)}
+              onClick={() => setCancelReasonOpen(true)}
               disabled={cancelMutation.isPending}
               className="flex w-full items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50 sm:w-auto sm:justify-start"
             >
@@ -254,18 +374,48 @@ export default function OrderDetailPage() {
         )}
       </div>
 
-      <ConfirmModal
-        open={confirmOpen}
-        title="주문 강제 취소"
-        description="이 주문을 강제 취소하시겠습니까?"
-        confirmLabel="주문 취소"
-        variant="danger"
-        onConfirm={() => {
-          cancelMutation.mutate()
-          setConfirmOpen(false)
-        }}
-        onCancel={() => setConfirmOpen(false)}
-      />
+      {/* 취소 사유 입력 모달 */}
+      {cancelReasonOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+            <h3 className="mb-4 text-base font-semibold text-gray-900">주문 강제 취소</h3>
+            <p className="mb-2 text-sm text-gray-600">이 주문을 강제 취소하시겠습니까?</p>
+            <p className="mb-3 text-sm font-semibold text-red-600">⚠️ 이 작업은 되돌릴 수 없습니다.</p>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">취소 사유 (선택)</label>
+              <textarea
+                value={cancelReason}
+                onChange={(e) => setCancelReason(e.target.value)}
+                placeholder="취소 사유를 입력하세요"
+                rows={3}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  setCancelReasonOpen(false)
+                  setCancelReason('')
+                }}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={() => {
+                  cancelMutation.mutate(cancelReason || undefined)
+                  setCancelReasonOpen(false)
+                  setCancelReason('')
+                }}
+                disabled={cancelMutation.isPending}
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                주문 취소
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <ToastContainer toasts={toast.toasts} />
     </div>

--- a/src/pages/OrdersPage.tsx
+++ b/src/pages/OrdersPage.tsx
@@ -2,11 +2,10 @@ import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Search, XCircle, Download } from 'lucide-react'
-import { getOrders, cancelOrder, exportOrders } from '../api/admin'
+import { getOrders, cancelOrderWithReason, exportOrders } from '../api/admin'
 import type { AdminOrder, Page } from '../types'
 import { cn } from '../lib/utils'
 import { label, orderStatusLabel } from '../lib/labels'
-import ConfirmModal from '../components/ConfirmModal'
 import ToastContainer from '../components/ToastContainer'
 import { useToast } from '../hooks/useToast'
 
@@ -31,8 +30,9 @@ export default function OrdersPage() {
   const [search, setSearch] = useState('')
   const [status, setStatus] = useState('ALL')
 
-  const [confirmOpen, setConfirmOpen] = useState(false)
   const [pendingCancelId, setPendingCancelId] = useState<string | null>(null)
+  const [cancelReasonOpen, setCancelReasonOpen] = useState(false)
+  const [cancelReason, setCancelReason] = useState('')
 
   const [eventIdInput, setEventIdInput] = useState(eventId ? String(eventId) : '')
   const [sortField, setSortField] = useState<string>('')
@@ -51,7 +51,8 @@ export default function OrdersPage() {
   })
 
   const cancelMutation = useMutation({
-    mutationFn: cancelOrder,
+    mutationFn: ({ orderId, reason }: { orderId: string; reason?: string }) =>
+      cancelOrderWithReason(orderId, reason),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['orders'] })
       toast.success('주문이 취소되었습니다.')
@@ -70,7 +71,7 @@ export default function OrdersPage() {
   const handleCancel = (e: React.MouseEvent, orderId: string) => {
     e.stopPropagation()
     setPendingCancelId(orderId)
-    setConfirmOpen(true)
+    setCancelReasonOpen(true)
   }
 
   const handleExport = async () => {
@@ -349,22 +350,56 @@ export default function OrdersPage() {
         )}
       </div>
 
-      <ConfirmModal
-        open={confirmOpen}
-        title="주문 취소"
-        description="이 주문을 취소하시겠습니까?"
-        confirmLabel="주문 취소"
-        variant="danger"
-        onConfirm={() => {
-          if (pendingCancelId) cancelMutation.mutate(pendingCancelId)
-          setConfirmOpen(false)
-          setPendingCancelId(null)
-        }}
-        onCancel={() => {
-          setConfirmOpen(false)
-          setPendingCancelId(null)
-        }}
-      />
+      {/* 취소 사유 입력 모달 */}
+      {cancelReasonOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => {
+            setCancelReasonOpen(false)
+            setPendingCancelId(null)
+            setCancelReason('')
+          }}
+        >
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl" onClick={(e) => e.stopPropagation()}>
+            <h3 className="mb-4 text-base font-semibold text-gray-900">주문 취소</h3>
+            <p className="mb-3 text-sm text-gray-600">이 주문을 취소하시겠습니까?</p>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">취소 사유 (선택)</label>
+              <textarea
+                value={cancelReason}
+                onChange={(e) => setCancelReason(e.target.value)}
+                placeholder="취소 사유를 입력하세요"
+                rows={3}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  setCancelReasonOpen(false)
+                  setPendingCancelId(null)
+                  setCancelReason('')
+                }}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={() => {
+                  if (pendingCancelId) cancelMutation.mutate({ orderId: pendingCancelId, reason: cancelReason || undefined })
+                  setCancelReasonOpen(false)
+                  setPendingCancelId(null)
+                  setCancelReason('')
+                }}
+                disabled={cancelMutation.isPending}
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                주문 취소
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <ToastContainer toasts={toast.toasts} />
     </div>

--- a/src/pages/UserDetailPage.tsx
+++ b/src/pages/UserDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft } from 'lucide-react'
-import { getUserDetail, updateUserRole, updateUserStatus } from '../api/admin'
+import { getUserDetail, updateUserRole, updateUserStatus, updateUserName } from '../api/admin'
 import type { AdminUserDetail } from '../types'
 import { cn } from '../lib/utils'
 import { label, roleLabel, accountStateLabel } from '../lib/labels'
@@ -37,6 +37,8 @@ export default function UserDetailPage() {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [pendingRole, setPendingRole] = useState<string | null>(null)
   const [statusConfirmOpen, setStatusConfirmOpen] = useState(false)
+  const [isEditingName, setIsEditingName] = useState(false)
+  const [newName, setNewName] = useState('')
 
   const { data: user, isLoading } = useQuery<AdminUserDetail>({
     queryKey: ['user', userId],
@@ -67,6 +69,27 @@ export default function UserDetailPage() {
       toast.error('계정 상태 변경에 실패했습니다.')
     },
   })
+
+  const nameMutation = useMutation({
+    mutationFn: (name: string) => updateUserName(userId, name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user', userId] })
+      queryClient.invalidateQueries({ queryKey: ['users'] })
+      toast.success('이름이 변경되었습니다.')
+      setIsEditingName(false)
+    },
+    onError: () => {
+      toast.error('이름 변경에 실패했습니다.')
+    },
+  })
+
+  const handleChangeName = () => {
+    if (newName.length < 2 || newName.length > 7) {
+      toast.error('이름은 2~7자여야 합니다.')
+      return
+    }
+    nameMutation.mutate(newName)
+  }
 
   if (isLoading) {
     return (
@@ -100,7 +123,45 @@ export default function UserDetailPage() {
       <div className="rounded-xl bg-white p-6 shadow-sm">
         <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h2 className="text-xl font-bold text-gray-900">{user.name}</h2>
+            <div className="flex items-center gap-2">
+              {isEditingName ? (
+                <>
+                  <input
+                    type="text"
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    maxLength={7}
+                    className="rounded-lg border border-gray-300 px-2 py-1 text-xl font-bold text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  />
+                  <button
+                    onClick={handleChangeName}
+                    disabled={nameMutation.isPending}
+                    className="rounded-lg bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    저장
+                  </button>
+                  <button
+                    onClick={() => setIsEditingName(false)}
+                    className="rounded-lg border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+                  >
+                    취소
+                  </button>
+                </>
+              ) : (
+                <>
+                  <h2 className="text-xl font-bold text-gray-900">{user.name}</h2>
+                  <button
+                    onClick={() => {
+                      setNewName(user.name)
+                      setIsEditingName(true)
+                    }}
+                    className="rounded-lg border border-gray-300 px-2 py-0.5 text-xs font-medium text-gray-600 hover:bg-gray-50"
+                  >
+                    수정
+                  </button>
+                </>
+              )}
+            </div>
             <p className="text-sm text-gray-500">{user.email}</p>
           </div>
           <div className="flex flex-wrap items-center gap-2">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,7 +95,6 @@ export interface AdminOrder {
   discountAmount?: string
   couponName?: string
   failReason?: string
-  userRefundReason?: string
   cancelReason?: string
   refundStatus?: string
   refundStatusChangedAt?: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,6 +94,11 @@ export interface AdminOrder {
   supplyAmount?: string
   discountAmount?: string
   couponName?: string
+  failReason?: string
+  userRefundReason?: string
+  cancelReason?: string
+  refundStatus?: string
+  refundStatusChangedAt?: string
 }
 
 export interface AdminComment {


### PR DESCRIPTION
## Summary

Backend #681 환불 플로우 리디자인에 맞춰 UI 수정.

- `userRefundReason` 타입/표시 제거
- `REFUND_REJECTED` 배지/라벨/버튼 제거
- 환불 완료 버튼만 유지 (REFUND_REQUESTED일 때)

### 테스트
- [x] 빌드 통과
- [x] 37 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)